### PR TITLE
fix TypeError 

### DIFF
--- a/components/common/Footer.js
+++ b/components/common/Footer.js
@@ -52,9 +52,9 @@ export default class Footer extends React.Component {
         (window.innerHeight - dimentions.top) / window.innerHeight;
 
       this.images.forEach((image, index) => {
+        const translateRatio = imagesInfo[index] ? imagesInfo[index].translateRatio : 0;
         image &&
-          (image.style.transform = `translateY(${scrolledRatio *
-            imagesInfo[index].translateRatio}px)`);
+          (image.style.transform = `translateY(${scrolledRatio * translateRatio}px)`);
       });
     }
   };


### PR DESCRIPTION
- fix TyeError by checking if imagesInfo is undefined before selecting translateRatio property

How to replicate error:
- not have fix from this PR in Footer `example-checkout-hifi/components/common/Footer.js`
- Go to `http://localhost:3000/product/hair-oil`
- Scroll down to footer
- See error below 
![image](https://user-images.githubusercontent.com/30238579/80507211-9ba0a780-8944-11ea-811a-1079a32e969c.png)
