### PR TITLE
[CHEC-580] - bugfix with cart

### DIFF
--- a/pages/product/[permalink].js
+++ b/pages/product/[permalink].js
@@ -31,12 +31,6 @@ class Product extends Component {
     };
   }
 
-  /**
-  * Retrieve cart and contents client-side to dispatch to store
-  */
-  componentDidMount() {
-    this.props.dispatch(retrieveCart());
-  }
 
   render() {
     const { showShipping,showDetails } = this.state;


### PR DESCRIPTION
so seemed like the fix was a duplicate of calling the `cart.retrieve` in `[permalink.js]` as well as in the `Cart.js` component. it was strange as I was getting John to replicate the bug but was working just fine for him. but im still not sure as to why retrieving carts in two components would fetch a new cart. does it have to do with when each component mounts?