### PR TITLE
[CHEC-580] Bugfix/cart

### DIFF
--- a/pages/product/[permalink].js
+++ b/pages/product/[permalink].js
@@ -31,12 +31,6 @@ class Product extends Component {
     };
   }
 
-  /**
-  * Retrieve cart and contents client-side to dispatch to store
-  */
-  componentDidMount() {
-    this.props.dispatch(retrieveCart());
-  }
 
   render() {
     const { showShipping,showDetails } = this.state;

--- a/pages/product/[permalink].js
+++ b/pages/product/[permalink].js
@@ -14,8 +14,6 @@ import Footer from "../../components/common/Footer";
 import CategoryList from '../../components/products/CategoryList';
 import reduceProductImages from '../../lib/reduceProductImages';
 
-import { retrieveCart } from '../../store/actions/cartActions';
-
 const detailView = `<p>
       Slightly textured fabric with tonal geometric design and a bit of shine
     </p>`;

--- a/store/actions/cartActions.js
+++ b/store/actions/cartActions.js
@@ -37,9 +37,15 @@ export const retrieveCartError = (error) => {
 /**
  * Async retrieve cart from API
  */
-export const retrieveCart = () => dispatch => commerce.cart.retrieve()
-  .then(cart => dispatch(retrieveCartSuccess(cart)))
-  .catch(error => dispatch(retrieveCartError(error)));
+export const retrieveCart = () => {
+  return (dispatch, getState) => {
+    if (getState().cart) {
+      return Promise.resolve();
+    }
+    return commerce.cart.retrieve().then(cart => dispatch(retrieveCartSuccess(cart)))
+      .catch(error => dispatch(retrieveCartError(error)));
+  }
+}
 
 
 /**

--- a/store/index.js
+++ b/store/index.js
@@ -80,7 +80,11 @@ const reducer = (state = initialState, action) => {
 // Enable Redux dev tools
 const devtools = (process.browser && window.__REDUX_DEVTOOLS_EXTENSION__)
   ? window.__REDUX_DEVTOOLS_EXTENSION__()
-  : f => f
+  /* Use the below commented out line if you want to enable tracing action calls, use only in dev mode as it will affect performance
+  https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Features/Trace.md */
+
+  // ? window.__REDUX_DEVTOOLS_EXTENSION__({ trace: true, traceLimit: 25 })
+  : f => f;
 
 
 // Create a makeStore function and pass in reducer to create the store


### PR DESCRIPTION
- added `getState.()` in cart action to check if cart exists already, if so don't retrieve again
- added option to trace redux actions in `store`
- I wasn't able to replicate the issue that came up during review, but was able to see at one point that the error was 'product variant cannot be found', so I would explicitly select the variant to add to cart each time in the UI and it was fine. when this error happened, would trigger an `ADD_TO_CART_ERROR` simply because no product variant was selected. if we want, maybe could rethink the UX around this, as each PDP would default to the first variant selected, instead we can somehow indicate that a variant must be selected in the UI.
- was either the above or cache issue with `cart.id`, i will test again in live deploy preview. seemed that error went away, was hard to debug with no issue in dev

![Kapture 2020-05-08 at 12 45 43](https://user-images.githubusercontent.com/48780927/81445497-d1f0da80-912d-11ea-8a15-31b86068d6fc.gif)
