### PR TITLE
Added demo merchant public key to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-CHEC_PUBLIC_KEY=
+# Public key from Chec's demo merchant account. This client key will enable you to deploy a live preview with Netlify's one-click deploy. Replace this key with your own account's public key afterwards.
+CHEC_PUBLIC_KEY=pk_178511bb808cdcaa54deba073eefe51688eb9cf470dfe
 # Secret key is used with chec/seeder to access your Chec account to seed it with sample data
 CHEC_API_URL=https://api.chec.io
 CHEC_SECRET_KEY=


### PR DESCRIPTION
- added public key to `.env.example` to enable one-click deploy to Netlify as per Robbie's suggestion
- alternate deployment with data seeding is included in manual setup
**Please refer to latest updates on README for provided steps**