### PR TITLE
Fix product images not loading at checkout.

### DIFF
--- a/pages/checkout/index.js
+++ b/pages/checkout/index.js
@@ -434,14 +434,13 @@ class CheckoutPage extends Component {
                 </div>
                 <div className="pt-3 borderbottom border-color-gray400">
                   {(checkout.live ? checkout.live.line_items : []).map((item, index, items) => {
-                    const _item = line_items.find(i => i.id === item.id); // from root checkout token object, not checkout.live, since it includes an image property
                     return (
                       <div
                         key={item.id}
                         className="d-flex mb-2"
                       >
-                        { (_item && _item.image)
-                          ? (<img className="checkout__line-item-image mr-2" src={_item.image} alt={_item.product_name}/>)
+                        { (item && item.media)
+                          ? (<img className="checkout__line-item-image mr-2" src={item.media.source} alt={item.product_name}/>)
                           : ''
                         }
                         <div className="d-flex flex-grow-1">


### PR DESCRIPTION
Fix issue #103 

Deleted line 437 because `{item}` now contains `{media}` property.

![Screenshot from 2020-10-03 14-11-11](https://user-images.githubusercontent.com/31045436/94990258-559ae000-0583-11eb-9d51-a78240799ad6.png)
