### PR TITLE
Doc update -> Added banner images and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
-# Demo Store with Commerce.js and Next.js 🛍️💳
+<p align="center">
+  <img src="https://raw.githubusercontent.com/chec/commercejs-examples/master/assets/logo.svg" width="500" height="100" /> 
+  <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8e/Nextjs-logo.svg/800px-Nextjs-logo.svg.png" width="20%" /></p>
 
+<h1 align="center"> Demo Store with Commerce.js and Next.js 🛍️💳 </h1>
+
+    
 [![Netlify Status](https://img.shields.io/netlify/157bb2e2-611e-4bbd-9a59-c876f8c3c58a?style=for-the-badge)](https://app.netlify.com/sites/commercejs-demo-store/deploys)
 [![Stars](https://img.shields.io/github/stars/chec/commercejs-nextjs-demo-store?style=for-the-badge)](https://github.com/chec/commercejs-nextjs-demo-store)
 [![Forks](https://img.shields.io/github/forks/chec/commercejs-nextjs-demo-store?style=for-the-badge)](https://github.com/chec/commercejs-nextjs-demo-store/fork)
 
-A high-fidelity fully-fledged eCommerce demo store built using the Commerce.js SDK and Next.js with live deployment to Netlify.
+
+A high-fidelity fully-fledged eCommerce demo store built using the [Commerce.js](https://commercejs.com/) SDK and Next.js with live deployment to Netlify.
 
 [![Chec see live demo button](https://cdn.chec.io/email/assets/marketing/chec-demo-btn.svg)](https://commercejs-demo-store.netlify.app)
 
 **Note**
-- This app is built using Commerce.js v2 SDK
+- This app is built using [Commerce.js](https://commercejs.com/) v2 SDK
 
 # Table of Contents
 


### PR DESCRIPTION
- Added banner images of both commerce.js and next.js
- Added links to **commerce.js** where ever mentioned in the doc


## Before:

![before](https://user-images.githubusercontent.com/55238388/96363228-93396480-1150-11eb-8557-1fa642edcafe.PNG)

## After:

![after](https://user-images.githubusercontent.com/55238388/96363242-afd59c80-1150-11eb-8e2d-a526c738e2de.PNG)

