### PR TITLE
Fix deploy failures by handling nullable product descriptions

### DIFF
--- a/components/products/ProductRow.js
+++ b/components/products/ProductRow.js
@@ -9,15 +9,15 @@ class ProductRow extends Component {
 
     return (
       <div className="row mb-5">
-        {products.map((product) => (
-          <div key={product.id} className="col-6 col-sm-6 col-lg-3">
+        {products.map(({ id, permalink, media, name, price, description }) => (
+          <div key={id} className="col-6 col-sm-6 col-lg-3">
             <ProductCard
-              id={product.id}
-              permalink={product.permalink}
-              image={product.media.source}
-              name={product.name}
-              price={product.price.formatted_with_symbol}
-              description={product.description.replace(reg, '')}
+              id={id}
+              permalink={permalink}
+              image={media.source}
+              name={name}
+              price={price.formatted_with_symbol}
+              description={description && description.replace(reg, '')}
             />
           </div>
         ))}


### PR DESCRIPTION
Product descriptions can return null if nothing is defined for them. We'll be changing this in the next API release so it always returns strings even when empty, but in the meantime this fixes https://github.com/chec/commercejs-nextjs-demo-store/issues/136
