### PR TITLE
fix: Fixes #130. Mobile menu styling

### DIFF
--- a/components/common/Header.js
+++ b/components/common/Header.js
@@ -238,7 +238,7 @@ class Header extends Component {
               }}
             >
               <div
-                className="position-absolute top-0 left-0 right-0 h-100vh mobile-menu-inner bg-black700 d-flex flex-column justify-content-center"
+                className="position-absolute left-0 right-0 h-100vh mobile-menu-inner bg-black700 d-flex flex-column justify-content-center"
                 style={{
                   // Prevent mobile menu items (e.g. Home) being hidden behind navbar on small screen heights (e.g. iPhone4 landscape of 320px height)
                   top: '4em'

--- a/components/common/Header.js
+++ b/components/common/Header.js
@@ -232,15 +232,23 @@ class Header extends Component {
               className="d-sm-none position-fixed top-0 left-0 right-0 overflow-hidden"
               style={{
                 ...defaultStyle,
-                ...transitionStyles[state]
+                ...transitionStyles[state],
+                // Prevent gap being shown at bottom of mobile menu
+                top: '1em'
               }}
             >
-              <div className="position-absolute top-0 left-0 right-0 h-100vh mobile-menu-inner bg-brand700 d-flex flex-column justify-content-center">
+              <div
+                className="position-absolute top-0 left-0 right-0 h-100vh mobile-menu-inner bg-black700 d-flex flex-column justify-content-center"
+                style={{
+                  // Prevent mobile menu items (e.g. Home) being hidden behind navbar on small screen heights (e.g. iPhone4 landscape of 320px height)
+                  top: '4em'
+                }}
+              >
                 {mobileMenuLinks.map((item, i) => (
                   <a
                     key={i}
                     href={item.link}
-                    className="d-block mb-4 font-size-heading font-color-black text-center"
+                    className="d-block mb-4 font-size-heading font-color-white text-center"
                   >
                     {item.name}
                   </a>

--- a/components/common/Header.js
+++ b/components/common/Header.js
@@ -229,7 +229,7 @@ class Header extends Component {
         <Transition in={showMobileMenu} timeout={duration}>
           {state => (
             <div
-              className="d-sm-none position-fixed top-0 left-0 right-0 overflow-hidden"
+              className="d-sm-none position-fixed left-0 right-0 overflow-hidden"
               style={{
                 ...defaultStyle,
                 ...transitionStyles[state],


### PR DESCRIPTION
* Change background colour to black
* Change link text colour to white
* Prevent gap from being shown at bottom of mobile menu by stretching the mobile menu popup so its height extends to the bottom of any screen (including Pixel 2 XL)
* Prevent mobile menu items (e.g. Home) being hidden behind navbar on small screen heights (e.g. iPhone4 landscape of 320px height)
* Note: Mobile menu appears on devices <576px wide