### PR TITLE
Restore Next's Automatic Static Optimization

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,63 +1,50 @@
 /* global process */
-import App from 'next/app';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import '../style/scss/style.scss';
-import { wrapper } from '../store';
-import { compose } from 'redux';
-import { connect } from 'react-redux';
+import { useStore } from '../store';
+import { Provider  } from 'react-redux';
 import commerce from '../lib/commerce';
 import { loadStripe } from '@stripe/stripe-js';
 import { setCustomer } from '../store/actions/authenticateActions';
 
-class MyApp extends App {
-  constructor(props) {
-    super(props);
+const MyApp = ({Component, pageProps}) => {
 
-    // If using Stripe, initialise it here. This allows Stripe to track behaviour
-    // as much as possible in order to determine fraud risk.
-    this.stripePromise = null;
+  const store = useStore(pageProps.initialState);
+  const [stripePromise, setStripePromise] = useState(null);
+
+  useEffect(() => {
     if (process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY) { // has API key
-        this.stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY);
+      setStripePromise(loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY));
     }
-  }
 
-  stripePromise = null;
+    setCustomer();
 
-  componentDidMount() {
-    this.props.setCustomer();
-  }
+    commerce.products.list().then((res) => {
+      store.dispatch({
+        type: 'STORE_PRODUCTS',
+        payload: res.data
+      })
+    });
 
-  static async getInitialProps({ Component, ctx }) {
-    // Fetch products
-    // Fetch categories
-    const { data: products } = await commerce.products.list();
-    const { data: categories } = await commerce.categories.list();
+    commerce.categories.list().then((res) => {
+      console.log(res.data)
+      store.dispatch({
+        type: 'STORE_CATEGORIES',
+        payload: res.data
+      })
+    });
 
-    // Allows store to be updated via the dispatch action
-    ctx.store.dispatch({ type: 'STORE_CATEGORIES', payload: categories });
-    ctx.store.dispatch({ type: 'STORE_PRODUCTS', payload: products });
+  }, [])
 
-    return {
-      pageProps: {
-        // Call page-level getInitialProps
-        ...(Component.getInitialProps ? await Component.getInitialProps(ctx) : {}),
-      }
-    };
-  }
-
-  render() {
-    const { Component, pageProps } = this.props;
-
-    return (
+  return (
+    <Provider store={store}>
       <Component
         {...pageProps}
-        stripe={this.stripePromise}
+        stripe={stripePromise}
       />
-    );
-  }
+    </Provider>
+  );
+
 }
 
-export default compose(
-  wrapper.withRedux, // HOC wrapper
-  connect(null, { setCustomer }) // function that returns wrapper
-)(MyApp);
+export default MyApp;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -34,7 +34,7 @@ const MyApp = ({Component, pageProps}) => {
       })
     });
 
-  }, [])
+  }, [store])
 
   return (
     <Provider store={store}>


### PR DESCRIPTION
Based on this Next.js thread : https://github.com/vercel/next.js/issues/9285#issue-516511684

And more or less related to this issue : #161

I've made big changes in Redux implementation to **avoid use of getInitialProps** in order to restore Next.js Automatic Static Optimization.

**It increases significantly performance on loading pages.**  I've gained a lot of speed at pages load time for this demo ! (not "scientifically" tested but i guess between 8 and 10 times faster)

However getInitialProps Or getServerSideProps can be useful for some use cases but as it sayed here : https://medium.com/swlh/fetching-and-hydrating-a-next-js-app-using-getserversideprops-and-getstaticprops-65bfe42afed8

`If used properly, these methods can be very powerful but, at the same time, they can be very harmful to the performance of your app when not taken with care.`

And indeed, it was ! ^^