### PR TITLE
Remove display none on the variants element

### DIFF
--- a/components/productAssets/ProductDetail.js
+++ b/components/productAssets/ProductDetail.js
@@ -138,7 +138,7 @@ class ProductDetail extends Component {
         <div className="mb-4 pb-3 font-size-subheader">{(description || '').replace(reg, '')}</div>
 
         {/* Product Variant */}
-          <div className="d-none d-sm-block">
+          <div className="d-sm-block">
             <VariantSelector
               className="mb-3"
               variantGroups={variantGroups}


### PR DESCRIPTION
Not sure why this was applied initially but removed the class to prevent variants from disappearing on small screens